### PR TITLE
README.md: INHERIT += "create-spdx" no longer necessary

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ This layer, named `meta-vulnscout`, requires your project to be built with the g
 If this is not the case yet, you can simply do the following to `build/conf/local.conf`:
 
 ```shell
-INHERIT += "create-spdx"
 INHERIT += "cve-check"
 include conf/distro/include/cve-extra-exclusions.inc
 ```


### PR DESCRIPTION
create-spdx.bbclass is inherited by default since version 4.3: https://docs.yoctoproject.org/migration-guides/release-notes-4.3.html

That's earlier than the only releases Scarthgap (5.0) and Walnascar (5.2) that this layer supports.

Also add missing newline at the end of this file.