### PR TITLE
README.md: fix typo on meta name

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ $ git clone https://github.com/savoirfairelinux/meta-vulnscout.git
 And in your `bblayers.conf` file:
 
 ```shell
-BBLAYERS += "/path/to/meta-cyclonedx"
+BBLAYERS += "/path/to/meta-vulnscout"
 ```
 
 ## Configuration


### PR DESCRIPTION
meta-vulnscout should be used instead of meta-cyclonedx.