### PR TITLE
Replace the COMPANY_NAME by AUTHOR_NAME for the docker-compose file

### DIFF
--- a/classes/vulnscout.bbclass
+++ b/classes/vulnscout.bbclass
@@ -63,8 +63,8 @@ EOF
     if [ -n "${VULNSCOUT_ENV_PRODUCT_VERSION}" ]; then
         echo "      - PRODUCT_VERSION=${VULNSCOUT_ENV_PRODUCT_VERSION}" >> "$compose_file"
     fi
-    if [ -n "${VULNSCOUT_ENV_COMPANY_NAME}" ]; then
-        echo "      - COMPANY_NAME=${VULNSCOUT_ENV_COMPANY_NAME}" >> "$compose_file"
+    if [ -n "${VULNSCOUT_ENV_AUTHOR_NAME}" ]; then
+        echo "      - AUTHOR_NAME=${VULNSCOUT_ENV_AUTHOR_NAME}" >> "$compose_file"
     fi
     if [ -n "${VULNSCOUT_ENV_CONTACT_EMAIL}" ]; then
         echo "      - CONTACT_EMAIL=${VULNSCOUT_ENV_CONTACT_EMAIL}" >> "$compose_file"
@@ -91,7 +91,7 @@ python do_vulnscout() {
     compose_cmd = ""
 
     if not os.path.exists(compose_file):
-        bb.fatal(f"Cannot start Vulnscout container: {compose_file} does not exist. Run do_vulnscout first.")
+        bb.fatal(f"Cannot start Vulnscout container: {compose_file} does not exist. Run do_setup_vulnscout first.")
 
     # Check if docker-compose exists on host
     if shutil.which("docker-compose"):


### PR DESCRIPTION
**Changes proposed in this pull request:**

- Replace the COMPANY_NAME by AUTHOR_NAME for the docker-compose file to be up to date with the Vulnscout Project PR84 (https://github.com/savoirfairelinux/vulnscout/pull/84) 
- Typo on the vulnscout.bbclass log message if the docker-compose.file is not created when launching the docker-compose command

**Status**
- [ ] READY
- [x] HOLD
- [ ] WIP (Work-In-Progress)

**How to verify this change**
Add to the vulnscout.bbclass the variable : VULNSCOUT_ENV_AUTHOR_NAME with a string. 
(Exemple : VULNSCOUT_ENV_AUTHOR_NAME = "Savoir-Linux")

And rebuild your Yocto image with vulnscout : _bibtbake <image_name> -c vulnscout_

Then export an OpenVEX file from the web dashboard.
In the OpenVEX output, you should see the author name you previously set.

