### PR TITLE
Change the vulnscout volume to input instead of output

### DIFF
--- a/classes/vulnscout.bbclass
+++ b/classes/vulnscout.bbclass
@@ -40,7 +40,7 @@ EOF
     ${@bb.utils.contains('INHERIT', 'cve-check', 'echo "      - ${DEPLOY_DIR_IMAGE}/${IMAGE_LINK_NAME}.json:/scan/inputs/yocto_cve_check/${IMAGE_LINK_NAME}.json:ro" >> $compose_file', '', d)}
     ${@bb.utils.contains('INHERIT', 'create-spdx', 'echo "      - ${DEPLOY_DIR_IMAGE}/${IMAGE_LINK_NAME}.spdx.tar.zst:/scan/inputs/spdx/${IMAGE_LINK_NAME}.spdx.tar.zst:ro" >> $compose_file', '', d)}
     ${@bb.utils.contains('INHERIT', 'cyclonedx-export', 'echo "      - ${DEPLOY_DIR}/cyclonedx-export:/scan/inputs/cdx:ro" >> $compose_file', '', d)}
-    echo "      - ${VULNSCOUT_DEPLOY_DIR}/output:/scan/outputs" >> "$compose_file"
+    echo "      - ${VULNSCOUT_DEPLOY_DIR}/output:/scan/input" >> "$compose_file"
     echo "      - ${VULNSCOUT_CACHE_DIR}:/cache/vulnscout" >> "$compose_file"
 
     # Add environnement variables


### PR DESCRIPTION
**Changes proposed in this pull request:**

The volume of the vulnscout output was set to "/scan/output" of the container. But vulnscout doesn't know how to classified these information. 
In order to do so, we need to set this volume in the "/scan/input" of the container.

**Status**
- [x] READY
- [x] HOLD
- [ ] WIP (Work-In-Progress)


**How to verify this change**
Comment all the volume expect the one coming from "${VULNSCOUT_DEPLOY_DIR}/output:/scan/input" in the vulnscout.bbclass
Launch vulnscout and on the dashboard all the vulnerabilities have grype as source.