### PR TITLE
Add nanbield support

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -10,7 +10,7 @@ BBFILE_PATTERN_meta-vulnscout = "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-vulnscout = "9"
 
 LAYERDEPENDS_meta-vulnscout = "core"
-LAYERSERIES_COMPAT_meta-vulnscout = "scarthgap"
+LAYERSERIES_COMPAT_meta-vulnscout = "nanbield"
 
 HOSTTOOLS_NONFATAL += "docker-compose docker"
 


### PR DESCRIPTION
This commit adds support for nanbield based yocto projects.
Vulnscout on nanbield currently works as intended and is up to par with
scarthgap.
