### PR TITLE
vulnscout.bbclass: Fix the tasks order

### DIFF
--- a/classes/vulnscout.bbclass
+++ b/classes/vulnscout.bbclass
@@ -85,8 +85,8 @@ EOF
         echo "      - NVD_API_KEY=${NVDCVE_API_KEY}" >> "$compose_file"
     fi
 
-    bbplain "Vulnscout Succeed: Docker Compose file set at ${VULNSCOUT_DEPLOY_DIR}/docker-compose.yml"
-    bbplain "Vulnscout Info: Start with the command 'docker-compose -f \"${VULNSCOUT_DEPLOY_DIR}/docker-compose.yml\" up'"
+    bbplain "Vulnscout Setup Succeed: Docker Compose file set at ${VULNSCOUT_DEPLOY_DIR}/docker-compose.yml"
+    bbplain "Vulnscout Info: After the build you can start web interface with the command 'docker-compose -f \"${VULNSCOUT_DEPLOY_DIR}/docker-compose.yml\" up'"
 
     # Delete do_vulnscout_ci flag
     rm -f "${WORKDIR}/vulnscout_ci_was_run"


### PR DESCRIPTION
**Changes** 

Fix the tasks order of vulnscout and vulnscout_ci to wait that the spdx file is correctly set under the deploy folder before launching vulnscout.
Also update logs

**How to test it**
Delete the files rootfs.json and rootfs.spdx.json in the folder _/build/tmp/deploy/images/../_ and build the project with vulnscout:
`bitbake <your_image> -c vulnscout` 

Then when it is done, check if the files were created correctly