### PR TITLE
vulnscout: add new task do_vulnscout_no_scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,12 @@ The scan and analysis of vulnerabilities can start with the yocto command:
 bitbake core-image-minimal -c vulnscout
 ```
 
+VulnScout Docker container can also be started without rescanning for new CVEs with the following command:
+
+```shell
+bitbake core-image-minimal -c do_vulnscout_no_scan
+```
+
 Or you can do it manually with the command:
 
 ```shell

--- a/classes/vulnscout.bbclass
+++ b/classes/vulnscout.bbclass
@@ -240,3 +240,29 @@ python do_vulnscout() {
 do_vulnscout[nostamp] = "1"
 do_vulnscout[doc] = "Open a new terminal and launch VulnScout web interface in a Docker container"
 addtask vulnscout after do_image_complete
+
+python do_vulnscout_no_scan(){
+    import os
+    cve_check_path = os.path.join(d.getVar("DEPLOY_DIR_IMAGE"), f"{d.getVar('IMAGE_LINK_NAME')}.json")
+    inherit_var = d.getVar('INHERIT') or ''
+    spdx_3_path = os.path.join(d.getVar("SPDXIMAGEDEPLOYDIR"), f"{d.getVar('IMAGE_LINK_NAME')}.spdx.json")
+    spdx_2_path = os.path.join(d.getVar("SPDXIMAGEDEPLOYDIR"), f"{d.getVar('IMAGE_LINK_NAME')}.spdx.tar.zst")
+
+    # Check the CVE-Check already exist
+    if not os.path.exists(cve_check_path):
+        bb.fatal(f"CVE-Check file not found at {cve_check_path}. Please enable 'cve-check' in INHERIT to generate it and rebuild the image.")
+
+    # Check the SPDX-2.2 or SPDX-3.0 files already exist based on INHERIT
+    if 'create-spdx-3.0' in inherit_var:
+        if not os.path.exists(spdx_3_path):
+            bb.fatal(f"SPDX-3.0 file not found at {spdx_3_path}. Please enable 'create-spdx-3.0' in INHERIT to generate it and rebuild the image.")
+    elif 'create-spdx' in inherit_var:
+        if not os.path.exists(spdx_2_path):
+            bb.fatal(f"SPDX-2.2 file not found at {spdx_2_path}. Please enable 'create-spdx' in INHERIT to generate it and rebuild the image.")
+
+    # Call the setup vulnscout to start the docker container
+    bb.build.exec_func("do_vulnscout",d)
+}
+do_vulnscout_no_scan[nostamp] = "1"
+do_vulnscout_no_scan[doc] = "Open a new terminal and launch VulnScout web interface in a Docker container without scanning the image"
+addtask vulnscout_no_scan


### PR DESCRIPTION
The new task do_vulnscout_no_scan starts the VulnScout Docker container without performing the recompilation of the image to get new CVEs with the task do_cve_check

Testing method: 

```
bitbake core-image-minimal -c do_vulnscout_no_scan
```

If the build was already complete then, it just start VulnScout web-interface without re-scanning the build