### PR TITLE
Add user id permissions, factorize check_file_requirements

### DIFF
--- a/classes/vulnscout.bbclass
+++ b/classes/vulnscout.bbclass
@@ -209,7 +209,7 @@ python do_vulnscout_ci() {
     output_vulnscout = d.getVar("VULNSCOUT_DEPLOY_DIR") + "/output/"
 
     # Deactive the interactive mode in the docker-compose file
-    subprocess.run(['sed', '-i', 's/INTERACTIVE_MODE=true/INTERACTIVE_MODE=false/g', ${VULNSCOUT_COMPOSE_FILE}])
+    subprocess.run(['sed', '-i', 's/INTERACTIVE_MODE=true/INTERACTIVE_MODE=false/g', compose_file])
 
     old_fail_condition = d.getVar("VULNSCOUT_ENV_FAIL_CONDITION")
     new_fail_condition = d.getVar("VULNSCOUT_FAIL_CONDITION",)


### PR DESCRIPTION
This PR brings these major changes:

* generate a .gitignore
* check file requirements when running do_vulnscout and not only when running do_vulnscout_no_scan
* add user uid and gid to the docker-compose.yml file so that vulnscout container from v0.11.0 will create files with the right permissions

This PR can be tested by running the tasks do_vulnscout and do_vulnscout_no_scan and verify that vulnscout in launching correctly in the browser