### PR TITLE
vulnscout: add an extra docker compose file

### DIFF
--- a/classes/vulnscout.bbclass
+++ b/classes/vulnscout.bbclass
@@ -24,8 +24,15 @@ do_setup_vulnscout() {
     # Define Output YAML file
     compose_file="${VULNSCOUT_DEPLOY_DIR}/docker-compose.yml"
 
+    if [ ! -e "${VULNSCOUT_DEPLOY_DIR}/docker-compose-additions.yml" ]; then
+        touch "${VULNSCOUT_DEPLOY_DIR}/docker-compose-additions.yml"
+    fi
+
     # Add Header section
     cat > "$compose_file" <<EOF
+include:
+  - ./docker-compose-additions.yml
+
 services:
   vulnscout:
     image: ${VULNSCOUT_DOCKER_IMAGE}:${VULNSCOUT_VERSION}


### PR DESCRIPTION
This file will be used to store permanent changes for the current project. Indeed, everytime we rebuild the main yocto image of a project, it overrides the `docker-compose.yml` file with the default options. If we want to store permanently additional options then this becomes hard to track.

The file `docker-compose-additions.yml` will be added in all cases, it can be empty and will not be overwritten when rebuilding the yocto image