### PR TITLE
Scarthgap: Add a new variable SCRIPT_FOLDER

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,14 +52,18 @@ Reverting these modifications will automatically make Vulnscout to use SPDX2.2 a
 
 `meta-vulnscout` provides other classes for accurate cve-check file generation:
 
--`kernel-generate-cve-exclusions.bbclass` can be used to integrate the script `generate-cve-exclusions-py` (reference : https://docs.yoctoproject.org/dev/singleindex.html#generate-cve-exclusions-py).
-It provides extra kernel CVE details and information through the variable `CVE_STATUS`.
+-`kernel-generate-cve-exclusions.bbclass` can be used to integrate the script `generate-cve-exclusions-py` (reference : [genere-cve-exclusion](https://docs.yoctoproject.org/dev/singleindex.html#generate-cve-exclusions-py)). \
+It provides extra kernel CVE details and information through the variable `CVE_STATUS`. \
 To integrate this script, a .bbappend on the kernel recipe can be used to add `inherit kernel-generate-cve-exclusions` as shown on the available example at meta-vulnscout/recipes-kernel/linux/linux-yocto_%.bbappend
 
--`improve_kernel_cve_report.bbclass` can be used to integrate the script `improve_kernel_cve_report.py` (reference: https://docs.yoctoproject.org/dev/singleindex.html#improve-kernel-cve-report-py).
-It reduces CVE false positives by 70%-80% and provides detailed responses for all kernel-related CVEs by analyzing the files used to build the kernel.
-To integrate this script, a .bbappend on the image recipe can be used to add `inherit improve_kernel_cve_report` as shown on the available example at meta-vulnscout/recipes-core/images/core-image-minimal.bbappend.
+-`improve_kernel_cve_report.bbclass` can be used to integrate the script `improve_kernel_cve_report.py` (reference : [improve_kernel_cve_report](https://docs.yoctoproject.org/dev/singleindex.html#improve-kernel-cve-report-py)). \
+It reduces CVE false positives by 70%-80% and provides detailed responses for all kernel-related CVEs by analyzing the files used to build the kernel. \
+To integrate this script, a .bbappend on the image recipe can be used to add `inherit improve_kernel_cve_report` as shown on the available example at meta-vulnscout/recipes-core/images/core-image-minimal.bbappend. \
 If your project is based on SPDX-3.0, the class `improve_kernel_cve_report-spdx-3.0` will have to be inherit instead of `improve_kernel_cve_report`.
+
+> [!WARNING]
+> By default, the classes `kernel-generate-cve-exclusions.bbclass`, and `improve_kernel_cve_report.bbclass` require locating meta-vulnscout next to `poky` or `openembedded-core` folder to find the python script correctly.
+This behaviour can be modified with the variable `SCRIPT_FOLDER` defined in `meta-vulnscout/conf/layer.conf`.
 
 ## Using VulnScout Web Interface
 

--- a/classes/improve_kernel_cve_report-base.bbclass
+++ b/classes/improve_kernel_cve_report-base.bbclass
@@ -26,7 +26,7 @@ python do_clean:append() {
 
 do_scout_extra_kernel_vulns() {
     new_cve_report_file="${DEPLOY_DIR_IMAGE}/${IMAGE_NAME}.scouted.json"
-    improve_kernel_cve_script="${COREBASE}/../meta-vulnscout/scripts/improve_kernel_cve_report.py"
+    improve_kernel_cve_script="${SCRIPT_FOLDER}/improve_kernel_cve_report.py"
 
     # Check that IMPROVE_KERNEL_SPDX_FILE is set and the file exists
     if [ -z "${IMPROVE_KERNEL_SPDX_FILE}" ] || [ ! -f "${IMPROVE_KERNEL_SPDX_FILE}" ]; then

--- a/classes/kernel-generate-cve-exclusions.bbclass
+++ b/classes/kernel-generate-cve-exclusions.bbclass
@@ -4,7 +4,7 @@ GENERATE_CVE_EXCLUSIONS_OUTPUT_INC  = "${WORKDIR}/temp//cve-exclusion_${LINUX_VE
 
 do_generate_cve_exclusions() {
     # Check for required files and directories
-    generate_cve_exclusions_script=${COREBASE}/../meta-vulnscout/scripts/generate-cve-exclusions.py
+    generate_cve_exclusions_script=${SCRIPT_FOLDER}/generate-cve-exclusions.py
     if [ ! -f "${generate_cve_exclusions_script}" ]; then
         bbwarn "generate-cve-exclusions.py not found in ${generate_cve_exclusions_script}."
         return 0

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -28,3 +28,6 @@ VULNS_USE_AUTOREV = "1"
 
 # Update COMMON_LICENSE_DIR to add meta-vulnscout licenses
 LICENSE_PATH:append = " ${LAYERDIR}/licenses"
+
+# Folder path to find the scripts python used by the different classes
+SCRIPT_FOLDER ?= "${COREBASE}/../meta-vulnscout/scripts"


### PR DESCRIPTION
By default, the classes `kernel-generate-cve-exclusions.bbclass`, and `improve_kernel_cve_report.bbclass` require locating meta-vulnscout next to `poky` or `openembedded-core` folder to find the python script correctly.  

This behaviour can be modified with the variable `SCRIPT_FOLDER` defined in `meta-vulnscout/conf/layer.conf`.