### PR TITLE
fix: support BB_NO_NETWORK

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -14,8 +14,8 @@ LAYERSERIES_COMPAT_meta-vulnscout = "scarthgap"
 
 HOSTTOOLS_NONFATAL += "docker-compose docker"
 
-# Inherit cve-check to generate CVE reports
-INHERIT += "cve-check"
+# Inherit cve-check to generate CVE reports but only if network is available
+INHERIT += "${@'cve-check' if not bb.utils.to_boolean(d.getVar("BB_NO_NETWORK")) else ''}"
 include conf/distro/include/cve-extra-exclusions.inc
 
 # Inherit create-spdx to generate SBOMs

--- a/recipes-kernel/cvelistv5-native/cvelistv5-native_git.bb
+++ b/recipes-kernel/cvelistv5-native/cvelistv5-native_git.bb
@@ -14,7 +14,7 @@ CVELISTV5_DEFAULT_SRCREV ?= "644ce1758db1773336ebebb6a0da90e132da0eb7"
 S = "${WORKDIR}/git"
 
 python __anonymous () {
-    if d.getVar("CVELISTV5_USE_AUTOREV") == "1":
+    if d.getVar("CVELISTV5_USE_AUTOREV") == "1" and not bb.utils.to_boolean(d.getVar("BB_NO_NETWORK")):
         d.setVar("SRCREV", d.getVar("AUTOREV"))
     else:
         d.setVar("SRCREV", d.getVar("CVELISTV5_DEFAULT_SRCREV"))

--- a/recipes-kernel/vulns-native/vulns-native_git.bb
+++ b/recipes-kernel/vulns-native/vulns-native_git.bb
@@ -14,7 +14,7 @@ VULNS_DEFAULT_SRCREV ?= "2c9b20d7a0699222b58c4824560b716b6096637b"
 S = "${WORKDIR}/git"
 
 python __anonymous () {
-    if d.getVar("VULNS_USE_AUTOREV") == "1":
+    if d.getVar("VULNS_USE_AUTOREV") == "1" and not bb.utils.to_boolean(d.getVar("BB_NO_NETWORK")):
         d.setVar("SRCREV", d.getVar("AUTOREV"))
     else:
         d.setVar("SRCREV", d.getVar("VULNS_DEFAULT_SRCREV"))


### PR DESCRIPTION
Currently, it is not possible to launch a Yocto build with the [BB_NO_NETWORK](https://docs.yoctoproject.org/bitbake/2.8/bitbake-user-manual/bitbake-user-manual-ref-variables.html#term-BB_NO_NETWORK) set to 1 since Internet access is required for the do_cve_check task inherited in the layer.conf of meta-vulnscout.

There is no way (to my knowledge) to circumvent this issue without tampering with meta-vulnscout since it's in the layer.conf file. This PR provides a fix by not inheriting the cve-check task if BB_NO_NETWORK is available. It also disables USE_AUTOREV for CVELISTV5 and VULNS to fix the same issue.