### PR TITLE
Scarthgap: improve_kernel_cve: move to a library

### DIFF
--- a/classes/improve_kernel_cve_report.bbclass
+++ b/classes/improve_kernel_cve_report.bbclass
@@ -1,41 +1,42 @@
 # Setting to specify the path to the SPDX file to be used for extra kernel vulnerabilities scouting
 IMPROVE_KERNEL_SPDX_FILE = "${DEPLOY_DIR_SPDX}/${@d.getVar('MACHINE').replace('-', '_')}/recipes/recipe-${PREFERRED_PROVIDER_virtual/kernel}.spdx.json"
 
-do_scout_extra_kernel_vulns() {
-    new_cve_report_file="${IMGDEPLOYDIR}/${IMAGE_NAME}.scouted.json"
-    improve_kernel_cve_script="${VULNSCOUT_SCRIPT_FOLDER}/improve_kernel_cve_report.py"
+python do_image_improve_kernel_cve_report() {
+    import os
+    import vulnscout.improve_kernel_cve_report as ikc
 
-    # Check that IMPROVE_KERNEL_SPDX_FILE is set and the file exists
-    if [ -z "${IMPROVE_KERNEL_SPDX_FILE}" ] || [ ! -f "${IMPROVE_KERNEL_SPDX_FILE}" ]; then
-        bbwarn "improve_kernel_cve: IMPROVE_KERNEL_SPDX_FILE is empty or file not found: ${IMPROVE_KERNEL_SPDX_FILE}"
-        return 0
-    fi
-    if [ ! -f "${CVE_CHECK_MANIFEST_JSON}" ]; then
-        bbwarn "improve_kernel_cve: CVE_CHECK file not found: ${CVE_CHECK_MANIFEST_JSON}. Skipping extra kernel vulnerabilities scouting."
-        return 0
-    fi
-    if [ ! -f "${improve_kernel_cve_script}" ]; then
-        bbwarn "improve_kernel_cve: improve_kernel_cve_report.py not found in ${COREBASE}."
-        return 0
-    fi
-    if [ ! -d "${STAGING_DATADIR_NATIVE}/vulns-native" ]; then
-        bbwarn "improve_kernel_cve: Vulnerabilities data not found in ${STAGING_DATADIR_NATIVE}/vulns-native."
-        return 0
-    fi
+    # Define input files and paths
+    spdx_file = d.getVar('IMPROVE_KERNEL_SPDX_FILE')
+    old_cve_report = d.getVar('CVE_CHECK_MANIFEST_JSON')
+    imgdeploydir = d.getVar('IMGDEPLOYDIR')
+    image_name = d.getVar('IMAGE_NAME')
+    image_basename = d.getVar('IMAGE_BASENAME')
+    image_machine_suffix = d.getVar('IMAGE_MACHINE_SUFFIX')
+    image_name_suffix = d.getVar('IMAGE_NAME_SUFFIX')
+    datadir = os.path.join(d.getVar('STAGING_DATADIR_NATIVE'), 'vulns-native')
+    new_cve_report = os.path.join(imgdeploydir, f"{image_name}.scouted.json")
 
-    #Run the improve_kernel_cve_report.py script
-    bbplain "improve_kernel_cve: Using SPDX file for extra kernel vulnerabilities scouting: ${IMPROVE_KERNEL_SPDX_FILE}"
-    python3 "${improve_kernel_cve_script}" \
-        --spdx "${IMPROVE_KERNEL_SPDX_FILE}" \
-        --old-cve-report "${CVE_CHECK_MANIFEST_JSON}" \
-        --new-cve-report "${new_cve_report_file}" \
-        --datadir "${STAGING_DATADIR_NATIVE}/vulns-native"
-    bbplain "improve CVE report with extra kernel cves: ${new_cve_report_file}"
+    if not spdx_file or not os.path.isfile(spdx_file):
+        bb.warn(f"improve_kernel_cve: IMPROVE_KERNEL_SPDX_FILE is empty or file not found: {spdx_file}")
+        return
+    if not old_cve_report or not os.path.isfile(old_cve_report):
+        bb.warn(f"improve_kernel_cve: CVE_CHECK file not found: {old_cve_report}. Skipping extra kernel vulnerabilities scouting.")
+        return
+    if not os.path.isdir(datadir):
+        bb.warn(f"improve_kernel_cve: Vulnerabilities data not found in {datadir}.")
+        return
 
-    #Create a symlink as every other JSON file in tmp/deploy/images
-    ln -sf ${IMAGE_NAME}.scouted.json ${IMGDEPLOYDIR}/${IMAGE_BASENAME}${IMAGE_MACHINE_SUFFIX}${IMAGE_NAME_SUFFIX}.scouted.json
+    bb.note(f"improve_kernel_cve: Using SPDX file for extra kernel vulnerabilities scouting: {spdx_file}")
+    ikc.kernel_improve_cve_report(spdx_file, old_cve_report, new_cve_report, datadir)
+    bb.note(f"improve CVE report with extra kernel CVEs: {new_cve_report}")
+
+    symlink = os.path.join(imgdeploydir, f"{image_basename}{image_machine_suffix}{image_name_suffix}.scouted.json")
+    target = f"{image_name}.scouted.json"  # relative, not absolute
+    if os.path.islink(symlink) or os.path.exists(symlink):
+        os.remove(symlink)
+    os.symlink(target, symlink)
 }
-do_scout_extra_kernel_vulns[depends] += "vulns-native:do_populate_sysroot"
-do_scout_extra_kernel_vulns[nostamp] = "1"
-do_scout_extra_kernel_vulns[doc] = "Scout extra kernel vulnerabilities and create a new enhanced version of the cve_check file in the deploy directory"
-addtask do_scout_extra_kernel_vulns after do_rootfs before do_image_complete
+do_image_improve_kernel_cve_report[depends] += "vulns-native:do_populate_sysroot"
+do_image_improve_kernel_cve_report[nostamp] = "1"
+do_image_improve_kernel_cve_report[doc] = "Scout extra kernel vulnerabilities and create a new enhanced version of the cve_check file in the deploy directory"
+addtask do_image_improve_kernel_cve_report after do_rootfs before do_image_complete

--- a/lib/vulnscout/improve_kernel_cve_report.py
+++ b/lib/vulnscout/improve_kernel_cve_report.py
@@ -383,118 +383,35 @@ def cve_update(cve_data, cve, entry):
     logging.warning("Unhandled CVE entry update for %s %s from %s %s to %s",
         cve, cve_data[cve]['status'], cve_data[cve]['detail'],  entry['status'], entry['detail'])
 
-def main():
-    parser = argparse.ArgumentParser(
-        description="Update cve-summary with kernel compiled files and kernel CVE information"
-    )
-    parser.add_argument(
-        "-s",
-        "--spdx",
-        help="SPDX2/3 for the kernel. Needs to include compiled sources",
-    )
-    parser.add_argument(
-        "--debug-sources-file",
-        help="Debug sources zstd file generated from Yocto",
-    )
-    parser.add_argument(
-        "--datadir",
-        type=pathlib.Path,
-        help="Directory where CVE data is",
-        required=True
-    )
-    parser.add_argument(
-        "--old-cve-report",
-        help="CVE report to update. (Optional)",
-    )
-    parser.add_argument(
-        "--kernel-version",
-        help="Kernel version. Needed if old cve_report is not provided (Optional)",
-        type=Version
-    )
-    parser.add_argument(
-        "--new-cve-report",
-        help="Output file",
-        default="cve-summary-enhance.json"
-    )
-    parser.add_argument(
-        "-D",
-        "--debug",
-        help='Enable debug ',
-        action="store_true")
+def kernel_improve_cve_report(spdx_file, old_cve_report_path, new_cve_report_path, datadir):
+    """
+    Main entry point for the library. Reads the SPDX and CVE report,
+    enriches CVE data with kernel vuln info, and writes the result.
+    """
+    compiled_files = read_spdx(spdx_file)
+    logging.info("Total compiled files %d", len(compiled_files))
 
-    args = parser.parse_args()
-
-    if args.debug:
-        log_level=logging.DEBUG
-    else:
-        log_level=logging.INFO
-    logging.basicConfig(format='[%(filename)s:%(lineno)d] %(message)s', level=log_level)
-
-    if not args.kernel_version and not args.old_cve_report:
-        parser.error("either --kernel-version or --old-cve-report are needed")
-        return -1
-
-    # by default we don't check the compiled files, unless provided
-    compiled_files = []
-    if args.spdx:
-        compiled_files = read_spdx(args.spdx)
-        logging.info("Total compiled files %d", len(compiled_files))
-    if args.debug_sources_file:
-        compiled_files = read_debugsources(args.debug_sources_file)
-        logging.info("Total compiled files %d", len(compiled_files))
-
-    if args.old_cve_report:
-        with open(args.old_cve_report, encoding='ISO-8859-1') as f:
-            cve_report = json.load(f)
-    else:
-        #If summary not provided, we create one
-        cve_report = {
-            "version": "1",
-            "package": [
-                {
-                    "name": "linux-yocto",
-                    "version": str(args.kernel_version),
-                    "products": [
-                        {
-                            "product": "linux_kernel",
-                            "cvesInRecord": "Yes"
-                        }
-                    ],
-                    "issue": []
-                }
-            ]
-        }
+    with open(old_cve_report_path, encoding='ISO-8859-1') as f:
+        cve_report = json.load(f)
 
     for pkg in cve_report['package']:
-        is_kernel = False
-        for product in pkg['products']:
-            if product['product'] == "linux_kernel":
-                is_kernel=True
-        if not is_kernel:
+        if not any(p['product'] == "linux_kernel" for p in pkg.get('products', [])):
             continue
-        # We remove custom versions after -
+
         upstream_version = Version(pkg["version"].split("-")[0])
         logging.info("Checking kernel %s", upstream_version)
-        kernel_cves = get_kernel_cves(args.datadir,
-                                      compiled_files,
-                                      upstream_version)
-        logging.info("Total kernel cves from kernel CNA: %s", len(kernel_cves))
+
+        kernel_cves = get_kernel_cves(datadir, compiled_files, upstream_version)
+        logging.info("Total kernel CVEs from kernel CNA: %s", len(kernel_cves))
+
         cves = {issue["id"]: issue for issue in pkg["issue"]}
-        logging.info("Total kernel before processing cves: %s", len(cves))
+        logging.info("Total kernel CVEs before processing: %s", len(cves))
 
         for cve in kernel_cves:
             cve_update(cves, cve, kernel_cves[cve])
 
-        pkg["issue"] = []
-        for cve in sorted(cves):
-            pkg["issue"].extend([cves[cve]])
-        logging.info("Total kernel cves after processing: %s", len(pkg['issue']))
+        pkg["issue"] = [cves[cve] for cve in sorted(cves)]
+        logging.info("Total kernel CVEs after processing: %s", len(pkg['issue']))
 
-    with open(args.new_cve_report, "w", encoding='ISO-8859-1') as f:
+    with open(new_cve_report_path, "w", encoding='ISO-8859-1') as f:
         json.dump(cve_report, f, indent=2)
-
-    return 0
-
-if __name__ == "__main__":
-    sys.exit(main())
-


### PR DESCRIPTION
The script is moved to a library. The library is now called inside the bbclass, instead of using a python3 command on the script.

This approach is used by the meta layer in meta/lib/oe.