### PR TITLE
scarthgap: separate vulnscout settings in different distro files

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,21 +41,41 @@ BBLAYERS += "/path/to/meta-vulnscout"
 
 ## Configuration
 
-To enable and configure VulnScout, add `inherit vulnscout` in your image recipe.
+To enable and configure VulnScout, follow these 2 simple steps:
 
-Alternatively the class can be inherited in all image recipes automatically
-using IMAGE_CLASSES, by adding in your `local.conf`:
+1. First, add the following lines to your `local.conf` or distro config:
+
+```sh
+# Required settings for VulnScout
+include conf/distro/include/vulnscout-core.inc
+```
+
+2. Then, add `inherit vulnscout` in your image recipe, or add this line in your
+   `local.conf` or distro config to enable VulnScout in all image recipes:
 
 ```sh
 IMAGE_CLASSES += "vulnscout"
 ```
 
-This project contains an example as described in
-`recipes-core/images/core-image-minimal.bbappend`.
+
+The distro `poky-vulnscout` provided in this repo provides an example of a
+complete usage of meta-vulnscout features.
 
 ## Extra VulnScout configuration for cve-check improvements
 
-`meta-vulnscout` provides other classes for accurate cve-check file generation:
+`meta-vulnscout` provides other classes for accurate cve-check file generation.
+
+### Configuration
+
+Add this line to your distro config or `local.conf` to inherit the extra
+classes:
+
+```sh
+# Enable extra CVE analysis
+include conf/distro/include/vulnscout-cve-check.inc
+```
+
+### Description
 
 - `kernel_generate_cve_exclusions.bbclass` can be used to integrate a library
   `lib/vulnscout/generate_cve_exclusions_py` derived from the script
@@ -93,7 +113,8 @@ This project contains an example as described in
   file will be affected and the final cve-check manifest will be affected by
   this class analysis setting all non-built CVEs to `Ignored` status with
   `details` set to `cve-not-compiled-in-kernel` and `description` to
-  `kernel_filter_nonbuilt_cves detected that this CVE is not affecting the current kernel build.`
+  `kernel_filter_nonbuilt_cves detected that this CVE is not affecting the
+  current kernel build.`
 
 ## Using VulnScout Web Interface
 

--- a/classes/improve_kernel_cve_report.bbclass
+++ b/classes/improve_kernel_cve_report.bbclass
@@ -1,6 +1,11 @@
 # Setting to specify the path to the SPDX file to be used for extra kernel vulnerabilities scouting
 IMPROVE_KERNEL_SPDX_FILE = "${DEPLOY_DIR_SPDX}/${@d.getVar('MACHINE').replace('-', '_')}/recipes/recipe-${PREFERRED_PROVIDER_virtual/kernel}.spdx.json"
 
+python __anonymous() {
+    if not bb.data.inherits_class("cve-check", d):
+        bb.fatal("improve_kernel_cve: must inherit cve-check for using this class")
+}
+
 python do_image_improve_kernel_cve_report() {
     import os
     import vulnscout.improve_kernel_cve_report as ikc

--- a/classes/kernel_filter_nonbuilt_cves.bbclass
+++ b/classes/kernel_filter_nonbuilt_cves.bbclass
@@ -1,3 +1,8 @@
+python __anonymous() {
+    if not bb.data.inherits_class("cve-check", d):
+        bb.fatal("kernel_filter_nonbuilt_cves: must inherit cve-check for using this class")
+}
+
 python do_kernel_filter_nonbuilt_cves() {
     import os
     import vulnscout.kernel_filter_nonbuilt_cves as kf
@@ -16,13 +21,13 @@ python do_kernel_filter_nonbuilt_cves() {
 
     # Check that the required files exist before running the script
     if not os.path.isfile(input_cve_check):
-        bb.warn(f"kernel-filter-nonbuilt-cves: cve-check file not found: {input_cve_check}")
+        bb.warn(f"kernel_filter_nonbuilt_cves: cve-check file not found: {input_cve_check}")
         return
     if not os.path.isdir(vulns_path):
-        bb.warn(f"kernel-filter-nonbuilt-cves: Vulnerabilities data not found in {vulns_path}")
+        bb.warn(f"kernel_filter_nonbuilt_cves: Vulnerabilities data not found in {vulns_path}")
         return
     if not os.path.isdir(kernel_build_path):
-        bb.warn(f"kernel-filter-nonbuilt-cves: Kernel build directory not found: {kernel_build_path}")
+        bb.warn(f"kernel_filter_nonbuilt_cves: Kernel build directory not found: {kernel_build_path}")
         return
 
     # Step 1: Load Unpatched CVEs

--- a/classes/kernel_generate_cve_exclusions.bbclass
+++ b/classes/kernel_generate_cve_exclusions.bbclass
@@ -2,6 +2,11 @@
 GENERATE_CVE_EXCLUSIONS_OUTPUT_JSON ?= "${T}/cve-exclusion_${LINUX_VERSION}.json"
 GENERATE_CVE_EXCLUSIONS_OUTPUT_INC  ?= "${T}/cve-exclusion_${LINUX_VERSION}.inc"
 
+python __anonymous() {
+    if not bb.data.inherits_class("cve-check", d):
+        bb.fatal("kernel_generate_cve_exclusion: must inherit cve-check for using this class")
+}
+
 def get_kernel_version(d):
     """Get kernel version from LINUX_VERSION, falling back to PV."""
     linux_version = d.getVar('LINUX_VERSION')
@@ -25,7 +30,7 @@ python do_generate_cve_exclusions() {
     output_inc = d.getVar('GENERATE_CVE_EXCLUSIONS_OUTPUT_INC')
 
     if not os.path.isdir(datadir):
-        bb.warn(f"generate-cve-exclusions: CVE exclusions source directory not found in {datadir}")
+        bb.warn(f"kernel_generate_cve_exclusion: CVE exclusions source directory not found in {datadir}")
         return
 
     bb.note(f"Generating CVE exclusions for kernel version {kernel_version}")

--- a/conf/distro/include/vulnscout-core.inc
+++ b/conf/distro/include/vulnscout-core.inc
@@ -1,0 +1,5 @@
+# Inherit create-spdx to generate SBOMs
+# May be required if not using poky distro
+INHERIT += "create-spdx"
+
+HOSTTOOLS_NONFATAL += "docker-compose docker"

--- a/conf/distro/include/vulnscout-cve-check.inc
+++ b/conf/distro/include/vulnscout-cve-check.inc
@@ -1,0 +1,18 @@
+# Inherit cve-check to generate CVE reports
+INHERIT += "cve-check"
+include conf/distro/include/cve-extra-exclusions.inc
+
+# improve_kernel_cve_report class leverages CVE kernel metadata to generates a
+# new cve-check file with the extensio '.scouted.json'
+IMAGE_CLASSES += "improve_kernel_cve_report"
+
+# kernel_generate_cve_exclusions class updates the CVE_STATUS for the kernel recipe
+KERNEL_CLASSES += "kernel_generate_cve_exclusions"
+
+# kernel_filter_nonbuilt_cves class filters out CVEs not applicable to the
+# current kernel configuration
+KERNEL_CLASSES += "kernel_filter_nonbuilt_cves"
+
+# Use AUTOREV for additional classes
+CVELISTV5_USE_AUTOREV = "1"
+VULNS_USE_AUTOREV = "1"

--- a/conf/distro/poky-vulnscout.conf
+++ b/conf/distro/poky-vulnscout.conf
@@ -1,0 +1,5 @@
+require conf/distro/poky.conf
+require conf/distro/include/vulnscout-core.inc
+require conf/distro/include/vulnscout-cve-check.inc
+
+IMAGE_CLASSES += "vulnscout"

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -12,20 +12,6 @@ BBFILE_PRIORITY_meta-vulnscout = "9"
 LAYERDEPENDS_meta-vulnscout = "core"
 LAYERSERIES_COMPAT_meta-vulnscout = "scarthgap"
 
-HOSTTOOLS_NONFATAL += "docker-compose docker"
-
-# Inherit cve-check to generate CVE reports
-INHERIT += "cve-check"
-include conf/distro/include/cve-extra-exclusions.inc
-
-# Inherit create-spdx to generate SBOMs
-# May be required if not using poky distro
-INHERIT += "create-spdx"
-
-#Use AUTOREV for additional classes
-CVELISTV5_USE_AUTOREV = "1"
-VULNS_USE_AUTOREV = "1"
-
 # Update COMMON_LICENSE_DIR to add meta-vulnscout licenses
 LICENSE_PATH:append = " ${LAYERDIR}/licenses"
 

--- a/recipes-core/images/core-image-minimal.bbappend
+++ b/recipes-core/images/core-image-minimal.bbappend
@@ -1,4 +1,0 @@
-inherit vulnscout
-
-# Optional: add improve_kernel_cve_report class to generate improved CVE reports for the kernel
-inherit improve_kernel_cve_report

--- a/recipes-kernel/linux/linux-yocto_%.bbappend
+++ b/recipes-kernel/linux/linux-yocto_%.bbappend
@@ -1,5 +1,0 @@
-# Optional: add kernel-generate-cve-exclusions class to generate CVE exclusion files for the kernel
-inherit kernel_generate_cve_exclusions
-
-# Optional: add kernel-filter-nonbuilt-cves class to filter out CVEs not applicable to the current kernel defconfig
-inherit kernel_filter_nonbuilt_cves


### PR DESCRIPTION
The layer [meta-sbom-cve-check](https://github.com/bootlin/meta-sbom-cve-check) introduces a new file name, which is compatible with vulnscout, but has to be bind mounted in the right circumstances in the docker-compose.yml file