### PR TITLE
scarthgap: support SBOM CVE check

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ To enable and configure VulnScout, follow these 2 simple steps:
 
 ```sh
 # Required settings for VulnScout
-include conf/distro/include/vulnscout-core.inc
+require conf/distro/include/vulnscout-core.inc
 ```
 
 2. Then, add `inherit vulnscout` in your image recipe, or add this line in your
@@ -72,7 +72,7 @@ classes:
 
 ```sh
 # Enable extra CVE analysis
-include conf/distro/include/vulnscout-cve-check.inc
+require conf/distro/include/vulnscout-cve-check.inc
 ```
 
 ### Description

--- a/README.md
+++ b/README.md
@@ -267,6 +267,13 @@ If the container can't be configured (e.g., with kas-container).
 VulnScout web interface can still be run directly on the host with the
 `docker-compose` command.
 
+## Using [meta-sbom-cve-check](https://github.com/bootlin/meta-sbom-cve-check)
+
+The output of `meta-sbom-cve-check` is supported in VulnScout. However, this
+layer is incompatible with the cve-check improvements provided in
+`meta-vulnscout`. As a consequence, do not use
+`conf/distro/include/vulnscout-cve-check.inc` with `meta-sbom-cve-check`.
+
 ## Result
 
 ![Screenshot](doc/vulnscout-ui.png)

--- a/classes/vulnscout.bbclass
+++ b/classes/vulnscout.bbclass
@@ -22,12 +22,14 @@ VULNSCOUT_ENV_IGNORE_PARSING_ERRORS ?= 'false'
 VULNSCOUT_ENV_CVE_CHECK_EXCLUDE_PATCHED ?= "false"
 
 python __anonymous() {
-    if bb.data.inherits_class("create-spdx-2.2", d):
+    if bb.data.inherits_class("sbom-cve-check", d):
+        bb.build.addtask("do_setup_vulnscout", "do_build", "do_sbom_cve_check", d)
+    elif bb.data.inherits_class("create-spdx-2.2", d):
         bb.build.addtask("do_setup_vulnscout", "do_build", "do_image_complete", d)
     elif bb.data.inherits_class("create-spdx-3.0", d):
         bb.build.addtask("do_setup_vulnscout", "do_build", "do_create_image_sbom_spdx", d)
     else:
-        bb.fatal("Neither create-spdx nor create-spdx-2.2 class is inherited, please inherit one of these classes in your distro or local.conf.")
+        bb.fatal("Neither create-spdx, nor create-spdx-3.0, nor create-spdx-2.2 class is inherited, please inherit one of these classes in your distro config or local.conf.")
 }
 
 # Helper function to check if Vulnscout required files are present on the host
@@ -36,24 +38,31 @@ check_vulnscout_requirements() {
     SPDX_2_PATH="${DEPLOY_DIR_IMAGE}/${IMAGE_LINK_NAME}.spdx.tar.zst"
     CVE_CHECK_PATH="${DEPLOY_DIR_IMAGE}/${IMAGE_LINK_NAME}.json"
     SCOUTED_CVE_CHECK_PATH="${DEPLOY_DIR_IMAGE}/${IMAGE_LINK_NAME}.scouted.json"
+    SBOM_CVE_CHECK_PATH="${DEPLOY_DIR_IMAGE}/${IMAGE_LINK_NAME}${@d.getVarFlag("SBOM_CVE_CHECK_EXPORT_FILE", "ext")}"
 
     # Check the CVE-Check already exist
-    if ${@'true' if d.getVarFlag('do_image_improve_kernel_cve_report', 'task') else 'false'}; then
-        if [ ! -e "${SCOUTED_CVE_CHECK_PATH}" ]; then
-            bbfatal "Scouted CVE-Check file not found at ${SCOUTED_CVE_CHECK_PATH}. Please rebuild the image."
-        fi
-    elif [ ! -e "${CVE_CHECK_PATH}" ]; then
-        bbfatal "CVE-Check file not found at ${CVE_CHECK_PATH}. Please enable 'cve-check' in INHERIT to generate it and rebuild the image."
+    if ${@bb.utils.contains('INHERIT', 'cve-check', 'true', 'false', d)}; then
+        if ${@'true' if d.getVarFlag('do_image_improve_kernel_cve_report', 'task') else 'false'}; then
+            if [ ! -e "${SCOUTED_CVE_CHECK_PATH}" ]; then
+                bbfatal "Scouted CVE-Check file not found at ${SCOUTED_CVE_CHECK_PATH}. Please rebuild the image."
+            fi
+        elif [ ! -e "${CVE_CHECK_PATH}" ]; then
+            bbfatal "CVE-Check file not found at ${CVE_CHECK_PATH}. Please enable 'cve-check' in INHERIT to generate it and rebuild the image."
+    fi
     fi
 
     # Check the SPDX-2.2 or SPDX-3.0 files already exist based on INHERIT
-    if ${@'true' if bb.data.inherits_class("create-spdx-3.0", d) else 'false'}; then
+    if ${@'true' if bb.data.inherits_class("sbom-cve-check", d) else 'false'}; then
+        if [ ! -e "${SBOM_CVE_CHECK_PATH}" ]; then
+            bbfatal "sbom-cve-check file not found at ${SBOM_CVE_CHECK_PATH}. Please rebuild the image."
+        fi
+    elif ${@'true' if bb.data.inherits_class("create-spdx-3.0", d) else 'false'}; then
         if [ ! -e "${SPDX_3_PATH}" ]; then
-            bbfatal "SPDX-3.0 file not found at ${SPDX_3_PATH}. Please enable 'create-spdx-3.0' in INHERIT to generate it and rebuild the image."
+            bbfatal "SPDX-3.0 file not found at ${SPDX_3_PATH}. Please rebuild the image."
         fi
     elif ${@'true' if bb.data.inherits_class("create-spdx-2.2", d) else 'false'}; then
         if [ ! -e "${SPDX_2_PATH}" ]; then
-            bbfatal "SPDX-2.2 file not found at ${SPDX_2_PATH}. Please enable 'create-spdx' in INHERIT to generate it and rebuild the image."
+            bbfatal "SPDX-2.2 file not found at ${SPDX_2_PATH}. Please rebuild the image."
         fi
     fi
 }
@@ -94,7 +103,10 @@ EOF
     fi
 
     # Test if we use SPDX 3.0 or SPDX 2.2
-    if ${@'true' if bb.data.inherits_class("create-spdx-3.0", d) else 'false'}; then
+    if ${@'true' if bb.data.inherits_class("sbom-cve-check", d) else 'false'}; then
+        SPDX_RELATIVE_PATH="$(realpath --no-symlinks --relative-to="${VULNSCOUT_DEPLOY_DIR}" "${DEPLOY_DIR_IMAGE}/${IMAGE_LINK_NAME}${@d.getVarFlag("SBOM_CVE_CHECK_EXPORT_FILE", "ext")}")"
+        echo "      - ${SPDX_RELATIVE_PATH}:/scan/inputs/spdx/${IMAGE_LINK_NAME}.cve-check.spdx.json:ro,Z" >> "${VULNSCOUT_COMPOSE_FILE}"
+    elif ${@'true' if bb.data.inherits_class("create-spdx-3.0", d) else 'false'}; then
         SPDX_RELATIVE_PATH="$(realpath --no-symlinks --relative-to="${VULNSCOUT_DEPLOY_DIR}" "${DEPLOY_DIR_IMAGE}/${IMAGE_LINK_NAME}.spdx.json")"
         echo "      - ${SPDX_RELATIVE_PATH}:/scan/inputs/spdx/${IMAGE_LINK_NAME}.spdx.json:ro,Z" >> "${VULNSCOUT_COMPOSE_FILE}"
     elif ${@'true' if bb.data.inherits_class("create-spdx-2.2", d) else 'false'}; then

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -15,8 +15,5 @@ LAYERSERIES_COMPAT_meta-vulnscout = "scarthgap"
 # Update COMMON_LICENSE_DIR to add meta-vulnscout licenses
 LICENSE_PATH:append = " ${LAYERDIR}/licenses"
 
-# Folder path to find the scripts python used by the different classes
-VULNSCOUT_SCRIPT_FOLDER = "${LAYERDIR}/scripts"
-
 # Add the library path for Python scripts
 addpylib ${LAYERDIR}/lib vulnscout


### PR DESCRIPTION
This PR makes meta-vulnscout be compatible with [meta-sbom-cve-check](https://github.com/bootlin/meta-sbom-cve-check) output format