### PR TITLE
vulnscout: allow to export env vars for templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ With this command, `vulnscout` will list all vulnerabilities critical (CVSS >=
 
 VulnScout supports additional custom templates for export files. These templates
 can be stored in the folder `.vulnscout/custom_templates`, and should follow the
-template format of VulnScout.
+[template format of VulnScout](https://github.com/savoirfairelinux/vulnscout/blob/main/doc/WRITING_TEMPLATES.adoc).
 
 To use custom templates, specify their names in your `local.conf` using:
 ```sh
@@ -224,6 +224,14 @@ Some default templates are already included in VulnScout:
 - `vulnerability_summary.txt`
 
 They can be used in `VULNSCOUT_ENV_GENERATE_DOCUMENTS`.
+
+### Use environment variables in templates
+
+In VulnScout templates, you can use environment variables as stated in the
+documentation. These variables should be automatically detected if they are in a
+template in the `custom_templates` directory, and that the template is in use in
+`VULNSCOUT_ENV_GENERATE_DOCUMENTS`. Then the content of the variable is appended
+to the environment in the docker compose file with `VULNSCOUT_TPL_` prefix.
 
 ## Accelerate NVD database download
 

--- a/classes/vulnscout.bbclass
+++ b/classes/vulnscout.bbclass
@@ -20,7 +20,6 @@ VULNSCOUT_ENV_FLASK_RUN_HOST ?= "0.0.0.0"
 VULNSCOUT_ENV_GENERATE_DOCUMENTS ?= "summary.adoc,time_estimates.csv"
 VULNSCOUT_ENV_IGNORE_PARSING_ERRORS ?= 'false'
 VULNSCOUT_ENV_CVE_CHECK_EXCLUDE_PATCHED ?= "false"
-VULNSCOUT_ENV_PASSTHROUGH ?= ""
 
 python __anonymous() {
     if bb.data.inherits_class("sbom-cve-check", d):
@@ -176,10 +175,24 @@ EOF
 }
 
 python setup_vulnscout_env() {
-    env_passthrough = (d.getVar("VULNSCOUT_ENV_PASSTHROUGH") or "").split()
+    import os
+    import re
+
+    generates_documents = (d.getVar("VULNSCOUT_ENV_GENERATE_DOCUMENTS") or "").split(",")
+    custom_tpl_dir = d.getVar("VULNSCOUT_CUSTOM_TEMPLATES_DIR") or ""
+    custom_tpl_list = os.scandir(custom_tpl_dir) if custom_tpl_dir else []
+    custom_templates = [tpl.name for tpl in custom_tpl_list if tpl.name in generates_documents]
+    env_regex = r'{{[ ]*env\([\'\"](\w*)[\'\"],?.*\)[ ]*}}'
+    env_passthrough = set()
+    for tpl in custom_templates:
+        with open(os.path.join(custom_tpl_dir, tpl)) as f:
+            for line in f.readlines():
+                for match in re.finditer(env_regex, line):
+                    env_passthrough.add(match.group(1))
     for varname in env_passthrough:
-        with open(d.getVar("VULNSCOUT_COMPOSE_FILE"), "a") as myfile:
-            myfile.write(f"      - VULNSCOUT_TPL_{varname}={d.getVar(varname)}\n")
+        with open(d.getVar("VULNSCOUT_COMPOSE_FILE"), "a") as f:
+            if d.getVar(varname):
+                f.write(f"      - VULNSCOUT_TPL_{varname}={d.getVar(varname)}\n")
 }
 
 python do_setup_vulnscout() {

--- a/classes/vulnscout.bbclass
+++ b/classes/vulnscout.bbclass
@@ -244,7 +244,7 @@ python clear_vulnscout_container() {
         for cid in containers:
             result = subprocess.run(['docker', 'rm', '-f', cid])
             if result.returncode != 0:
-                    bb.war(f"Failed to delete container {cid}: {result.stderr.strip()}")
+                    bb.warn(f"Failed to delete container {cid}: {result.stderr.strip()}")
                     success = False
         if success:
             retry_count = 0

--- a/classes/vulnscout.bbclass
+++ b/classes/vulnscout.bbclass
@@ -20,6 +20,7 @@ VULNSCOUT_ENV_FLASK_RUN_HOST ?= "0.0.0.0"
 VULNSCOUT_ENV_GENERATE_DOCUMENTS ?= "summary.adoc,time_estimates.csv"
 VULNSCOUT_ENV_IGNORE_PARSING_ERRORS ?= 'false'
 VULNSCOUT_ENV_CVE_CHECK_EXCLUDE_PATCHED ?= "false"
+VULNSCOUT_ENV_PASSTHROUGH ?= ""
 
 python __anonymous() {
     if bb.data.inherits_class("sbom-cve-check", d):
@@ -67,7 +68,7 @@ check_vulnscout_requirements() {
     fi
 }
 
-do_setup_vulnscout() {
+setup_vulnscout_main() {
     check_vulnscout_requirements
 
     # Create an output directory for vulnscout configuration
@@ -172,6 +173,18 @@ EOF
 
     bbplain "Vulnscout Setup Succeed: Docker Compose file set at ${VULNSCOUT_COMPOSE_FILE}"
     bbplain "Vulnscout Info: After the build you can start web interface with the command 'docker-compose -f ${VULNSCOUT_COMPOSE_FILE} up'"
+}
+
+python setup_vulnscout_env() {
+    env_passthrough = (d.getVar("VULNSCOUT_ENV_PASSTHROUGH") or "").split()
+    for varname in env_passthrough:
+        with open(d.getVar("VULNSCOUT_COMPOSE_FILE"), "a") as myfile:
+            myfile.write(f"      - VULNSCOUT_TPL_{varname}={d.getVar(varname)}\n")
+}
+
+python do_setup_vulnscout() {
+    bb.build.exec_func("setup_vulnscout_main", d)
+    bb.build.exec_func("setup_vulnscout_env", d)
 }
 do_setup_vulnscout[doc] = "Configure the yaml file required to start VulnScout in VULNSCOUT_DEPLOY_DIR"
 
@@ -343,10 +356,21 @@ addtask vulnscout after do_setup_vulnscout
 python do_vulnscout_no_scan(){
     # Call the check_vulnscout_requirements function to check requirements
     # before launching vulnscout
-    bb.build.exec_func("check_vulnscout_requirements",d)
+    bb.build.exec_func("check_vulnscout_requirements", d)
     # Call the vulnscout task to start the docker container
-    bb.build.exec_func("do_vulnscout",d)
+    bb.build.exec_func("do_vulnscout", d)
 }
 do_vulnscout_no_scan[nostamp] = "1"
 do_vulnscout_no_scan[doc] = "Open a new terminal and launch VulnScout web interface in a Docker container without scanning the image"
 addtask vulnscout_no_scan
+
+python do_vulnscout_ci_no_scan(){
+    # Call the check_vulnscout_requirements function to check requirements
+    # before launching vulnscout
+    bb.build.exec_func("check_vulnscout_requirements", d)
+    # Call the vulnscout task to start the docker container
+    bb.build.exec_func("do_vulnscout_ci", d)
+}
+do_vulnscout_ci_no_scan[nostamp] = "1"
+do_vulnscout_ci_no_scan[doc] = "Launch VulnScout in non-interactive mode without scanning the image. VULNSCOUT_FAIL_CONDITION can be used to set a fail condition"
+addtask vulnscout_ci_no_scan


### PR DESCRIPTION
This PR makes it possible to specify environment variables to pass to the vulnscout templates

To test it, add a template with an environment variable in it (ex `env("DISTRO")`) in the custom_templates folder, specify its name in `VULNSCOUT_ENV_GENERATE_DOCUMENTS` and use do_vulnscout_ci to generate the template

